### PR TITLE
Allow for non blocking movements

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,6 @@ stepper.run_to_position_mm(1000)
 
 stepper.run_to_position_mm(400)
 
-immediately. Call :py:meth:`stop` from another thread to abort the movement or
-join the returned thread to wait for it to finish.
-
 
 #-----------------------------------------------------------------------
 # move the motor 1 revolution

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ stepper.run_to_position_mm(1000)
 
 stepper.run_to_position_mm(400)
 
+``run_to_position_steps`` blocks until the movement is finished.  Pass
+``blocking=False`` to start the movement in a background thread and return
+immediately. Call :py:meth:`stop` from another thread to abort the movement or
+use ``wait_for_movement_finished_threaded()`` to wait for it to finish.
+
 
 #-----------------------------------------------------------------------
 # move the motor 1 revolution

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The GPIO pins can be specific when initiating the class.
 """
 test file for testing basic movement
 """
-
+from time import sleep
 from cl57t_raspberry_pi_stepper_drive.CL57TStepperDriver import *
 
 print("---")
@@ -109,8 +109,6 @@ stepper.run_to_position_mm(1000)
 
 stepper.run_to_position_mm(400)
 
-``run_to_position_steps`` blocks until the movement is finished.  Pass
-``blocking=False`` to start the movement in a background thread and return
 immediately. Call :py:meth:`stop` from another thread to abort the movement or
 use ``wait_for_movement_finished_threaded()`` to wait for it to finish.
 
@@ -128,6 +126,15 @@ use ``wait_for_movement_finished_threaded()`` to wait for it to finish.
 #
 # stepper.run_to_position_steps(400)                             #move to position 400
 # stepper.run_to_position_steps(0)                               #move to position 0
+
+#
+
+#-----------------------------------------------------------------------
+# move the motor 1000 steps or 2 seconds (which ever is lower)
+#-----------------------------------------------------------------------
+#stepper.run_to_position_steps(1000, blocking=False)
+#sleep(2)
+#stepper.stop()
 
 
 #-----------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ stepper.run_to_position_mm(1000)
 stepper.run_to_position_mm(400)
 
 immediately. Call :py:meth:`stop` from another thread to abort the movement or
-use ``wait_for_movement_finished_threaded()`` to wait for it to finish.
+join the returned thread to wait for it to finish.
 
 
 #-----------------------------------------------------------------------

--- a/src/cl57t_raspberry_pi_stepper_drive/CL57TStepperDriver.py
+++ b/src/cl57t_raspberry_pi_stepper_drive/CL57TStepperDriver.py
@@ -31,9 +31,9 @@ class CL57TStepperDriver:
         set_movement_abs_rel, get_current_position, set_current_position, set_max_speed,
         set_max_speed_fullstep, get_max_speed, set_acceleration, set_acceleration_fullstep,
         get_acceleration, stop, get_movement_phase, run_to_position_steps,
-        run_to_position_revolutions, run_to_position_steps_threaded,
-        run_to_position_revolutions_threaded, wait_for_movement_finished_threaded, run,
-        distance_to_go, compute_new_speed, run_speed, make_a_step, run_to_position_mm
+        run_to_position_revolutions, run,
+        distance_to_go, compute_new_speed, run_speed, make_a_step, run_to_position_mm,
+        _run_to_position_steps_blocking
     )
 
     BOARD = BOARD
@@ -195,24 +195,25 @@ class CL57TStepperDriver:
         def do_not_touch_homing_sensor():
             self.cl57t_logger.log("moving back so homing sensor is not touched", Loglevel.INFO)
             if homing_sensor_value():
-                self.run_to_position_steps(
+                self._run_to_position_steps_blocking(
                     999999999,
                     movement_abs_rel=MovementAbsRel.RELATIVE,
-                    stop_condition=lambda : homing_sensor_value() is False,
-                    blocking=True,
+                    stop_condition=lambda: homing_sensor_value() is False,
                 )
 
                 self.cl57t_logger.log("moving back a bit more", Loglevel.INFO)
-                self.run_to_position_steps(50, movement_abs_rel=MovementAbsRel.RELATIVE, blocking=True)
+                self._run_to_position_steps_blocking(
+                    50,
+                    movement_abs_rel=MovementAbsRel.RELATIVE,
+                )
 
         do_not_touch_homing_sensor()
 
         self.cl57t_logger.log("touching the homing sensor", Loglevel.INFO)
-        self.run_to_position_steps(
+        self._run_to_position_steps_blocking(
             -999999999,
             movement_abs_rel=MovementAbsRel.RELATIVE,
-            stop_condition=lambda : homing_sensor_value() is True,
-            blocking=True,
+            stop_condition=lambda: homing_sensor_value() is True,
         )
         self.cl57t_logger.log("first homing reached", Loglevel.INFO)
 
@@ -221,11 +222,10 @@ class CL57TStepperDriver:
         self.cl57t_logger.log("touching the homing sensor slower", Loglevel.INFO)
         self.set_acceleration(0)
         self.set_max_speed(50)
-        self.run_to_position_steps(
+        self._run_to_position_steps_blocking(
             -999999999,
             movement_abs_rel=MovementAbsRel.RELATIVE,
-            stop_condition=lambda : homing_sensor_value() is True,
-            blocking=True,
+            stop_condition=lambda: homing_sensor_value() is True,
         )
 
         self.cl57t_logger.log("second homing reached", Loglevel.INFO)

--- a/src/cl57t_raspberry_pi_stepper_drive/CL57TStepperDriver.py
+++ b/src/cl57t_raspberry_pi_stepper_drive/CL57TStepperDriver.py
@@ -198,11 +198,12 @@ class CL57TStepperDriver:
                 self.run_to_position_steps(
                     999999999,
                     movement_abs_rel=MovementAbsRel.RELATIVE,
-                    stop_condition=lambda : homing_sensor_value() is False
+                    stop_condition=lambda : homing_sensor_value() is False,
+                    blocking=True,
                 )
 
                 self.cl57t_logger.log("moving back a bit more", Loglevel.INFO)
-                self.run_to_position_steps(50, movement_abs_rel=MovementAbsRel.RELATIVE)
+                self.run_to_position_steps(50, movement_abs_rel=MovementAbsRel.RELATIVE, blocking=True)
 
         do_not_touch_homing_sensor()
 
@@ -210,7 +211,8 @@ class CL57TStepperDriver:
         self.run_to_position_steps(
             -999999999,
             movement_abs_rel=MovementAbsRel.RELATIVE,
-            stop_condition=lambda : homing_sensor_value() is True
+            stop_condition=lambda : homing_sensor_value() is True,
+            blocking=True,
         )
         self.cl57t_logger.log("first homing reached", Loglevel.INFO)
 
@@ -222,7 +224,8 @@ class CL57TStepperDriver:
         self.run_to_position_steps(
             -999999999,
             movement_abs_rel=MovementAbsRel.RELATIVE,
-            stop_condition=lambda : homing_sensor_value() is True
+            stop_condition=lambda : homing_sensor_value() is True,
+            blocking=True,
         )
 
         self.cl57t_logger.log("second homing reached", Loglevel.INFO)


### PR DESCRIPTION
I have implemented the blocking parameter for the methods run_to_position_steps, run_to_position_mm and run_to_position_revolutions which allows to use them without blocking execution. Furthermore I have added the stop method to halt the motor when a non blocking movement is ongoing.